### PR TITLE
Updated paths in Fabric repo

### DIFF
--- a/llm_templates_fabric.py
+++ b/llm_templates_fabric.py
@@ -17,8 +17,8 @@ def fabric_template_loader(template_path: str) -> Template:
     template_name = template_path.strip()
 
     # Build URLs for system and user prompts
-    system_url = f"https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/{template_name}/system.md"
-    user_url = f"https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/{template_name}/user.md"
+    system_url = f"https://raw.githubusercontent.com/danielmiessler/Fabric/main/data/patterns/{template_name}/system.md"
+    user_url = f"https://raw.githubusercontent.com/danielmiessler/Fabric/main/data/patterns/{template_name}/user.md"
 
     system_content = None
     user_content = None


### PR DESCRIPTION
The paths to the patterns in the Fabric repo seem to have changed. This updates them so filters work again.